### PR TITLE
 Fixed an 'InterpolationMissingOptionError' issue in pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,6 @@ docstring-quotes = single
 [tool:pytest]
 log_cli = 1
 log_cli_level = WARNING
-log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
-log_cli_date_format=%Y-%m-%d %H:%M:%S
+log_cli_format = %%(asctime)s [%%(levelname)8s] %%(message)s (%%(filename)s:%%(lineno)s)
+log_cli_date_format=%%Y-%%m-%%d %%H:%%M:%%S
 norecursedirs = .venv .git .mypy_cache .pytest_cache


### PR DESCRIPTION
Additional details below:
* https://github.com/pytest-dev/pytest/issues/3062
* https://github.com/pypa/pip/issues/5182